### PR TITLE
Fixed incorrect parentheses causing check for log() on null object.

### DIFF
--- a/consolation.js
+++ b/consolation.js
@@ -30,7 +30,7 @@ safe_console = {
 
 // If the browser has no usable console, use a no-op.
 safe_console.original_console = (function(){
-  return (typeof(window.console === 'object') && typeof(window.console.log) === 'function') ? window.console : safe_console.__no_op_console;
+  return (typeof(window.console) === 'object' && typeof(window.console.log) === 'function') ? window.console : safe_console.__no_op_console;
 })();
 
 // Define all no-op methods for dummy console


### PR DESCRIPTION
Found a bug while testing against IE11 in IE8 compatibility mode.
